### PR TITLE
fix: remove auth info on disconnect

### DIFF
--- a/libs/sdk/src/client.ts
+++ b/libs/sdk/src/client.ts
@@ -456,6 +456,8 @@ export class MoneriumClient {
     }
     this.#subscriptions.clear();
     this.#socket?.close();
+    this.#authorizationHeader = undefined;
+    this.bearerProfile = undefined;
   }
   /**
    * Revokes access

--- a/libs/sdk/test/client.test.ts
+++ b/libs/sdk/test/client.test.ts
@@ -512,5 +512,12 @@ describe('disconnect()', () => {
     await client.disconnect();
 
     expect(sessionStorageSpy).toHaveBeenCalledWith(STORAGE_CODE_VERIFIER);
+  })
+  it('should remove bearerProfile from the class instance', async () => {
+    const client = new MoneriumClient();
+
+    await client.disconnect();
+
+    expect(client.bearerProfile).toBeUndefined();
   });
 });


### PR DESCRIPTION
This PR closes #65, by:

- removing `bearerProfile` and `#authorizationHeader` in the class instance, when `disconnect` is called
- adding tests to verify that `bearerProfile` was properly deleted

Didn't know how to test for hard privacy fields.